### PR TITLE
Add Clippy CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     name: token_list
     runs-on: ubuntu-latest
     steps:
+      - run: rustup component add clippy
       - uses: actions/checkout@master
       - uses: actions-rs/cargo@v1
         with:
@@ -15,6 +16,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -W clippy::all
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
`token_deque` is clippy-warning free at the moment. To keep it that way, this PR adds a `cargo clippy` CI step. 

You might want to read about a limitation of this before you decide to merge: 

https://github.com/marketplace/actions/rust-clippy-check#limitations